### PR TITLE
Support WASM compilation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,16 @@ exclude = [".github/*", ".rusty-hook.toml"]
 [dependencies]
 tokio = { version = "^1.42", features = ["macros"] }
 serde = { version = "^1.0", features = ["derive"] }
-chrono = "0.4.39"
-openssl = { version = "^0.10", features = ["vendored"] }
 reqwest = "^0.12"
 thiserror = "2.0.9"
 serde_json = "^1.0"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+chrono = "0.4.39"
+openssl = { version = "^0.10", features = ["vendored"] }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+chrono = { version = "0.4.39", features = ["wasmbind"] }
 
 [dev-dependencies]
 rusty-hook = "^0.11"

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Just an [Anilist](https://anilist.co/) API wrapper made in Rust.
 - Basic functionality to interact with the Anilist API.
 - Asynchronous methods to load full details of entities like Anime, Manga, User, Person, and Character.
 - Comprehensive data models with detailed documentation.
+- **WebAssembly (WASM) Support**: The library can be compiled for `wasm32-unknown-unknown` target.
 
 ## Current status
 
@@ -19,6 +20,19 @@ Add the following to your `Cargo.toml`:
 ```toml
 [dependencies]
 rust-anilist = "*"
+```
+
+## WebAssembly (WASM)
+
+This library supports compilation to `wasm32-unknown-unknown`. When targeting WASM:
+
+- The `openssl` dependency is automatically excluded (as `reqwest` uses the browser's `fetch` API).
+- The `chrono` crate is automatically configured with the `wasmbind` feature to correctly handle time functions (like `Local::now()`) using the JavaScript `Date` API.
+
+To build for WASM, simply run:
+
+```bash
+cargo build --target wasm32-unknown-unknown
 ```
 
 ## Usage

--- a/queries/get_anime.graphql
+++ b/queries/get_anime.graphql
@@ -114,6 +114,25 @@ query ($id: Int) {
           siteUrl
         }
         role
+        voiceActors(sort: RELEVANCE) {
+          id
+          name {
+            first
+            middle
+            last
+            full
+            native
+            alternative
+            userPreferred
+          }
+          languageV2
+          image {
+            large
+            medium
+          }
+          gender
+          siteUrl
+        }
       }
     }
     staff(sort: RELEVANCE) {

--- a/src/client.rs
+++ b/src/client.rs
@@ -3,13 +3,10 @@
 
 //! This module contains the `Client` struct and its related types.
 
-use serde::Deserialize;
 use std::time::Duration;
 
 use crate::{
-    models::{
-        Anime, Character, Cover, Format, Image, Manga, MediaType, Person, Status, Title, User,
-    },
+    models::{Anime, Character, Manga, MediaType, Person, User},
     Error, Result,
 };
 
@@ -361,49 +358,32 @@ impl Client {
     ///
     /// ```
     /// # async fn f(client: rust_anilist::Client) -> rust_anilist::Result<()> {
-    /// let animes = client.search_anime("Naruto", 1, 10).await.unwrap();
+    /// let animes = client.search_anime("Naruto", 1, 10).await?;
     ///
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn search_anime(&self, title: &str, page: u16, limit: u16) -> Option<Vec<Anime>> {
+    pub async fn search_anime(&self, title: &str, page: u16, limit: u16) -> Result<Vec<Anime>> {
         let result = self
             .request(
                 MediaType::Anime,
                 Action::Search,
                 serde_json::json!({ "search": title, "page": page, "per_page": limit, }),
             )
-            .await
-            .map_err(|e| Error::ApiError(e.to_string()))
-            .unwrap();
+            .await?;
+
+        let mut animes = Vec::new();
 
         if let Some(medias) = result["data"]["Page"]["media"].as_array() {
-            let mut animes = Vec::new();
-
             for media in medias.iter() {
-                animes.push(Anime {
-                    id: media["id"].as_i64().unwrap(),
-                    id_mal: media["idMal"].as_i64(),
-                    title: Title::deserialize(&media["title"]).unwrap(),
-                    format: Format::deserialize(&media["format"]).unwrap(),
-                    status: Status::deserialize(&media["status"]).unwrap(),
-                    description: media["description"].as_str().unwrap().to_string(),
-                    cover: Cover::deserialize(&media["coverImage"]).unwrap(),
-                    banner: media["bannerImage"].as_str().map(String::from),
-                    average_score: media["averageScore"].as_u64().map(|x| x as u8),
-                    mean_score: media["meanScore"].as_u64().map(|x| x as u8),
-                    is_adult: media["isAdult"].as_bool().unwrap(),
-                    url: media["siteUrl"].as_str().unwrap().to_string(),
-
-                    client: self.clone(),
-                    ..Default::default()
-                });
+                if let Ok(mut anime) = serde_json::from_value::<Anime>(media.clone()) {
+                    anime.client = self.clone();
+                    animes.push(anime);
+                }
             }
-
-            return Some(animes);
         }
 
-        None
+        Ok(animes)
     }
 
     /// Search for mangas.
@@ -422,49 +402,32 @@ impl Client {
     ///
     /// ```
     /// # async fn f(client: rust_anilist::Client) -> rust_anilist::Result<()> {
-    /// let mangas = client.search_manga("Naruto", 1, 10).await.unwrap();
+    /// let mangas = client.search_manga("Naruto", 1, 10).await?;
     ///
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn search_manga(&self, title: &str, page: u16, limit: u16) -> Option<Vec<Manga>> {
+    pub async fn search_manga(&self, title: &str, page: u16, limit: u16) -> Result<Vec<Manga>> {
         let result = self
             .request(
                 MediaType::Manga,
                 Action::Search,
                 serde_json::json!({ "search": title, "page": page, "per_page": limit, }),
             )
-            .await
-            .map_err(|e| Error::ApiError(e.to_string()))
-            .unwrap();
+            .await?;
+
+        let mut mangas = Vec::new();
 
         if let Some(medias) = result["data"]["Page"]["media"].as_array() {
-            let mut mangas = Vec::new();
-
             for media in medias.iter() {
-                mangas.push(Manga {
-                    id: media["id"].as_i64().unwrap(),
-                    id_mal: media["idMal"].as_i64(),
-                    title: Title::deserialize(&media["title"]).unwrap(),
-                    format: Format::deserialize(&media["format"]).unwrap(),
-                    status: Status::deserialize(&media["status"]).unwrap(),
-                    description: media["description"].as_str().unwrap().to_string(),
-                    cover: Cover::deserialize(&media["coverImage"]).unwrap(),
-                    banner: media["bannerImage"].as_str().map(String::from),
-                    average_score: media["averageScore"].as_u64().map(|x| x as u8),
-                    mean_score: media["meanScore"].as_u64().map(|x| x as u8),
-                    is_adult: media["isAdult"].as_bool().unwrap(),
-                    url: media["siteUrl"].as_str().unwrap().to_string(),
-
-                    client: self.clone(),
-                    ..Default::default()
-                });
+                if let Ok(mut manga) = serde_json::from_value::<Manga>(media.clone()) {
+                    manga.client = self.clone();
+                    mangas.push(manga);
+                }
             }
-
-            return Some(mangas);
         }
 
-        None
+        Ok(mangas)
     }
 
     /// Search for users.
@@ -483,42 +446,32 @@ impl Client {
     ///
     /// ```
     /// # async fn f(client: rust_anilist::Client) -> rust_anilist::Result<()> {
-    /// let users = client.search_user("andrielfr", 1, 10).await.unwrap();
+    /// let users = client.search_user("andrielfr", 1, 10).await?;
     ///
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn search_user(&self, name: &str, page: u16, limit: u16) -> Option<Vec<User>> {
+    pub async fn search_user(&self, name: &str, page: u16, limit: u16) -> Result<Vec<User>> {
         let result = self
             .request(
                 MediaType::User,
                 Action::Search,
                 serde_json::json!({ "search": name, "page": page, "per_page": limit, }),
             )
-            .await
-            .map_err(|e| Error::ApiError(e.to_string()))
-            .unwrap();
+            .await?;
+
+        let mut vec = Vec::new();
 
         if let Some(users) = result["data"]["Page"]["users"].as_array() {
-            let mut vec = Vec::new();
-
             for user in users.iter() {
-                vec.push(User {
-                    id: user["id"].as_i64().unwrap() as i32,
-                    name: user["name"].as_str().unwrap().to_string(),
-                    about: user["about"].as_str().map(String::from),
-                    avatar: Image::deserialize(&user["avatar"]).ok(),
-                    banner: user["bannerImage"].as_str().map(String::from),
-
-                    client: self.clone(),
-                    ..Default::default()
-                });
+                if let Ok(mut user) = serde_json::from_value::<User>(user.clone()) {
+                    user.client = self.clone();
+                    vec.push(user);
+                }
             }
-
-            return Some(vec);
         }
 
-        None
+        Ok(vec)
     }
 
     /// Send a request to the AniList API.
@@ -537,8 +490,8 @@ impl Client {
         media_type: MediaType,
         action: Action,
         variables: serde_json::Value,
-    ) -> std::result::Result<serde_json::Value, reqwest::Error> {
-        let query = Client::get_query(media_type, action).unwrap();
+    ) -> Result<serde_json::Value> {
+        let query = Client::get_query(media_type, action)?;
         let json = serde_json::json!({"query": query, "variables": variables});
         let mut body = reqwest::Client::new()
             .post("https://graphql.anilist.co/")
@@ -552,7 +505,7 @@ impl Client {
         }
 
         let response = body.send().await?.text().await?;
-        let result = serde_json::from_str::<serde_json::Value>(&response).unwrap();
+        let result = serde_json::from_str::<serde_json::Value>(&response)?;
 
         Ok(result)
     }
@@ -579,7 +532,7 @@ impl Client {
                     MediaType::User => include_str!("../queries/get_user.graphql").to_string(),
                     MediaType::Person => include_str!("../queries/get_person.graphql").to_string(),
                     // MediaType::Studio => include_str!("../queries/get_studio.graphql").to_string(),
-                    _ => unimplemented!(),
+                    _ => return Err(Error::UnsupportedMediaType),
                 }
             }
             Action::Search => {
@@ -594,7 +547,7 @@ impl Client {
                     //     include_str!("../queries/search_person.graphql").to_string()
                     // }
                     // MediaType::Studio => include_str!("../queries/search_studio.graphql").to_string(),
-                    _ => unimplemented!(),
+                    _ => return Err(Error::UnsupportedMediaType),
                 }
             }
         };

--- a/src/error.rs
+++ b/src/error.rs
@@ -24,4 +24,10 @@ pub enum Error {
     /// An error indicating that the API returned an invalid response.
     #[error("Failed to parse JSON")]
     JsonParseError(#[from] serde_json::Error),
+    /// An error indicating that the request failed.
+    #[error("http error: `{0}`")]
+    HttpError(#[from] reqwest::Error),
+    /// An error indicating that the media type or action is not supported.
+    #[error("unsupported media type or action")]
+    UnsupportedMediaType,
 }

--- a/src/models/anime.rs
+++ b/src/models/anime.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2022-2025 Andriel Ferreira <https://github.com/AndrielFR>
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 
 use super::{
@@ -83,12 +83,13 @@ pub struct Anime {
     /// The relations of the anime.
     pub(crate) relations: Value,
     /// The characters of the anime.
-    pub(crate) characters: Value,
+    #[serde(rename = "characters", deserialize_with = "deserialize_characters")]
+    pub characters: Option<Vec<Character>>,
     /// The staff of the anime.
-    #[serde(skip)]
+    #[serde(rename = "staff", deserialize_with = "deserialize_staff")]
     pub staff: Option<Vec<Person>>,
     /// The studios of the anime.
-    #[serde(skip)]
+    #[serde(rename = "studios", deserialize_with = "deserialize_studios")]
     pub studios: Option<Vec<Studio>>,
     /// Whether the anime is favourite or not.
     pub is_favourite: Option<bool>,
@@ -143,32 +144,6 @@ impl Anime {
         }
     }
 
-    /// Returns the characters of the anime.
-    pub fn characters(&self) -> Result<Vec<Character>> {
-        let binding = Vec::new();
-        let edges = self
-            .characters
-            .as_object()
-            .and_then(|obj| obj.get("edges"))
-            .and_then(|edges| edges.as_array())
-            .unwrap_or(&binding);
-
-        let mut characters = Vec::with_capacity(edges.len());
-
-        for edge in edges {
-            let binding = serde_json::Map::new();
-            let obj = edge.as_object().unwrap_or(&binding);
-            let node = obj.get("node").unwrap_or(&Value::Null);
-            let role = obj.get("role").and_then(|role| role.as_str()).unwrap_or("");
-
-            let mut character: Character = serde_json::from_value(node.clone()).unwrap_or_default();
-            character.role = Some(role.into());
-            characters.push(character);
-        }
-
-        Ok(characters)
-    }
-
     /// Returns the relations of the anime.
     pub fn relations(&self) -> Result<Vec<Relation>> {
         let binding = Vec::new();
@@ -205,4 +180,70 @@ pub struct AiringSchedule {
     pub time_until: u64,
     /// The airing episode.
     pub episode: u32,
+}
+
+fn deserialize_studios<'de, D>(deserializer: D) -> std::result::Result<Option<Vec<Studio>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    struct StudioConnection {
+        nodes: Vec<Studio>,
+    }
+    let connection: Option<StudioConnection> = Option::deserialize(deserializer)?;
+    Ok(connection.map(|c| c.nodes))
+}
+
+fn deserialize_characters<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Option<Vec<Character>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct CharacterEdge {
+        node: Character,
+        role: Option<String>,
+        voice_actors: Option<Vec<Person>>,
+    }
+    #[derive(Deserialize)]
+    struct CharacterConnection {
+        edges: Vec<CharacterEdge>,
+    }
+
+    let connection: Option<CharacterConnection> = Option::deserialize(deserializer)?;
+
+    match connection {
+        Some(conn) => {
+            let characters = conn
+                .edges
+                .into_iter()
+                .map(|edge| {
+                    let mut character = edge.node;
+                    if let Some(role_str) = edge.role {
+                        character.role = Some(role_str.into());
+                    }
+                    if let Some(voice_actors) = edge.voice_actors {
+                        character.voice_actors = Some(voice_actors);
+                    }
+                    character
+                })
+                .collect();
+            Ok(Some(characters))
+        }
+        None => Ok(None),
+    }
+}
+
+fn deserialize_staff<'de, D>(deserializer: D) -> std::result::Result<Option<Vec<Person>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    struct StaffConnection {
+        nodes: Vec<Person>,
+    }
+    let connection: Option<StaffConnection> = Option::deserialize(deserializer)?;
+    Ok(connection.map(|c| c.nodes))
 }

--- a/src/models/anime.rs
+++ b/src/models/anime.rs
@@ -18,7 +18,7 @@ use crate::{Client, Result};
 /// hashtags, images, genres, synonyms, scores, popularity, tags,
 /// relations, characters, staff, studios, and other metadata.
 #[derive(Debug, Default, Clone, PartialEq, Deserialize, Serialize)]
-#[serde(rename_all(deserialize = "camelCase"))]
+#[serde(default, rename_all(deserialize = "camelCase"))]
 pub struct Anime {
     /// The ID of the anime.
     pub id: i64,

--- a/src/models/gender.rs
+++ b/src/models/gender.rs
@@ -21,11 +21,11 @@ pub enum Gender {
     NonBinary,
     /// Represents a custom gender specified by a string.
     #[serde(untagged)]
-    Other(String),
+    Other(Option<String>),
 }
 
 impl Default for Gender {
     fn default() -> Self {
-        Gender::Other(String::from("Neutral"))
+        Gender::Other(Some(String::from("Neutral")))
     }
 }

--- a/src/models/language.rs
+++ b/src/models/language.rs
@@ -65,6 +65,8 @@ pub enum Language {
     Hindi,
     /// The Urdu language.
     Urdu,
+    /// The Polish language.
+    Polish,
 }
 
 impl Language {
@@ -97,6 +99,7 @@ impl Language {
             Language::Nepali => "ne",
             Language::Hindi => "hi",
             Language::Urdu => "ur",
+            Language::Polish => "pl",
         }
     }
 
@@ -136,6 +139,7 @@ impl Language {
             Language::Nepali => "नेपाली",
             Language::Hindi => "हिंदी",
             Language::Urdu => "اردو",
+            Language::Polish => "Polski",
         }
     }
 }
@@ -169,6 +173,7 @@ impl From<&str> for Language {
             "NE" | "NEPALI" => Language::Nepali,
             "HI" | "HINDI" => Language::Hindi,
             "UR" | "URDU" => Language::Urdu,
+            "PL" | "POLISH" => Language::Polish,
             _ => Language::default(),
         }
     }
@@ -209,6 +214,7 @@ impl std::fmt::Display for Language {
             Language::Nepali => write!(f, "Nepali"),
             Language::Hindi => write!(f, "Hindi"),
             Language::Urdu => write!(f, "Urdu"),
+            Language::Polish => write!(f, "Polish"),
         }
     }
 }
@@ -245,6 +251,7 @@ mod tests {
         assert_eq!(Language::Nepali.code(), "ne");
         assert_eq!(Language::Hindi.code(), "hi");
         assert_eq!(Language::Urdu.code(), "ur");
+        assert_eq!(Language::Polish.code(), "pl");
     }
 
     #[test]
@@ -275,6 +282,7 @@ mod tests {
         assert_eq!(Language::Nepali.iso(), "ne");
         assert_eq!(Language::Hindi.iso(), "hi");
         assert_eq!(Language::Urdu.iso(), "ur");
+        assert_eq!(Language::Polish.iso(), "pl");
     }
 
     #[test]
@@ -305,6 +313,7 @@ mod tests {
         assert_eq!(Language::Nepali.native(), "नेपाली");
         assert_eq!(Language::Hindi.native(), "हिंदी");
         assert_eq!(Language::Urdu.native(), "اردو");
+        assert_eq!(Language::Polish.native(), "Polski");
     }
 
     #[test]
@@ -335,6 +344,7 @@ mod tests {
         assert_eq!(Language::from("ne"), Language::Nepali);
         assert_eq!(Language::from("hi"), Language::Hindi);
         assert_eq!(Language::from("ur"), Language::Urdu);
+        assert_eq!(Language::from("pl"), Language::Polish);
         assert_eq!(Language::from("unknown"), Language::Japanese); // Default case
     }
 
@@ -366,6 +376,7 @@ mod tests {
         assert_eq!(Language::from("ne".to_string()), Language::Nepali);
         assert_eq!(Language::from("hi".to_string()), Language::Hindi);
         assert_eq!(Language::from("ur".to_string()), Language::Urdu);
+        assert_eq!(Language::from("pl".to_string()), Language::Polish);
         assert_eq!(Language::from("unknown".to_string()), Language::Japanese); // Default case
     }
 }

--- a/src/models/manga.rs
+++ b/src/models/manga.rs
@@ -19,7 +19,7 @@ use crate::{Client, Result};
 /// hashtags, images, genres, synonyms, scores, popularity, tags,
 /// relations, characters, staff, studios, and other metadata.
 #[derive(Debug, Default, Clone, PartialEq, Deserialize, Serialize)]
-#[serde(rename_all(deserialize = "camelCase"))]
+#[serde(default, rename_all(deserialize = "camelCase"))]
 pub struct Manga {
     /// The ID of the manga.
     pub id: i64,

--- a/src/models/name.rs
+++ b/src/models/name.rs
@@ -10,26 +10,26 @@ use serde::{Deserialize, Serialize};
 #[serde(rename_all(deserialize = "camelCase"))]
 pub struct Name {
     /// The first name.
-    pub first: String,
+    pub first: Option<String>,
     /// The middle name, if any.
     pub middle: Option<String>,
     /// The last name, if any.
     pub last: Option<String>,
     /// The full name.
-    full: String,
+    pub full: Option<String>,
     /// The native name, if any.
-    native: Option<String>,
+    pub native: Option<String>,
     /// Alternative names.
-    alternative: Vec<String>,
+    pub alternative: Vec<String>,
     /// Alternative names that may contain spoilers.
-    alternative_spoiler: Option<Vec<String>>,
+    pub alternative_spoiler: Option<Vec<String>>,
     /// The name preferred by the user, if any.
-    user_preferred: Option<String>,
+    pub user_preferred: Option<String>,
 }
 
 impl Name {
     /// Returns the full name.
-    pub fn full(&self) -> String {
+    pub fn full(&self) -> Option<String> {
         self.full.clone()
     }
 
@@ -61,26 +61,26 @@ mod tests {
     #[test]
     fn test_full() {
         let name = Name {
-            first: "John".to_string(),
+            first: Some("John".to_string()),
             middle: Some("Doe".to_string()),
             last: Some("Smith".to_string()),
-            full: "John Doe Smith".to_string(),
+            full: Some("John Doe Smith".to_string()),
             native: Some("ジョン ドウ スミス".to_string()),
             alternative: vec!["Johnny".to_string()],
             alternative_spoiler: Some(vec!["J.D.".to_string()]),
             user_preferred: Some("John Smith".to_string()),
         };
 
-        assert_eq!(name.full(), "John Doe Smith");
+        assert_eq!(name.full(), Some("John Doe Smith".to_string()));
     }
 
     #[test]
     fn test_native() {
         let name = Name {
-            first: "John".to_string(),
+            first: Some("John".to_string()),
             middle: Some("Doe".to_string()),
             last: Some("Smith".to_string()),
-            full: "John Doe Smith".to_string(),
+            full: Some("John Doe Smith".to_string()),
             native: Some("ジョン ドウ スミス".to_string()),
             alternative: vec!["Johnny".to_string()],
             alternative_spoiler: Some(vec!["J.D.".to_string()]),
@@ -93,10 +93,10 @@ mod tests {
     #[test]
     fn test_alternative() {
         let name = Name {
-            first: "John".to_string(),
+            first: Some("John".to_string()),
             middle: Some("Doe".to_string()),
             last: Some("Smith".to_string()),
-            full: "John Doe Smith".to_string(),
+            full: Some("John Doe Smith".to_string()),
             native: Some("ジョン ドウ スミス".to_string()),
             alternative: vec!["Johnny".to_string()],
             alternative_spoiler: Some(vec!["J.D.".to_string()]),
@@ -109,10 +109,10 @@ mod tests {
     #[test]
     fn test_spoiler() {
         let name = Name {
-            first: "John".to_string(),
+            first: Some("John".to_string()),
             middle: Some("Doe".to_string()),
             last: Some("Smith".to_string()),
-            full: "John Doe Smith".to_string(),
+            full: Some("John Doe Smith".to_string()),
             native: Some("ジョン ドウ スミス".to_string()),
             alternative: vec!["Johnny".to_string()],
             alternative_spoiler: Some(vec!["J.D.".to_string()]),
@@ -125,10 +125,10 @@ mod tests {
     #[test]
     fn test_user_preferred() {
         let name = Name {
-            first: "John".to_string(),
+            first: Some("John".to_string()),
             middle: Some("Doe".to_string()),
             last: Some("Smith".to_string()),
-            full: "John Doe Smith".to_string(),
+            full: Some("John Doe Smith".to_string()),
             native: Some("ジョン ドウ スミス".to_string()),
             alternative: vec!["Johnny".to_string()],
             alternative_spoiler: Some(vec!["J.D.".to_string()]),

--- a/src/models/person.rs
+++ b/src/models/person.rs
@@ -48,7 +48,7 @@ pub struct Person {
     #[serde(skip)]
     pub characters: Option<Vec<Character>>,
     /// The number of favorites the person has.
-    pub favourites: i64,
+    pub favourites: Option<i64>,
     /// The moderator notes for the person, if any.
     pub mod_notes: Option<String>,
 

--- a/src/models/studio.rs
+++ b/src/models/studio.rs
@@ -22,7 +22,8 @@ pub struct Studio {
     /// Whether the studio is an animation studio.
     pub is_animation_studio: bool,
     /// The URL of the studio.
-    pub url: String,
+    #[serde(rename = "siteUrl")]
+    pub url: Option<String>,
     /// Whether the studio is a favorite.
     pub is_favourite: Option<bool>,
     /// The number of favorites the studio has.

--- a/src/models/studio.rs
+++ b/src/models/studio.rs
@@ -27,7 +27,7 @@ pub struct Studio {
     /// Whether the studio is a favorite.
     pub is_favourite: Option<bool>,
     /// The number of favorites the studio has.
-    pub favourites: i64,
+    pub favourites: Option<i64>,
 }
 
 impl Studio {

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -18,7 +18,7 @@ use crate::{Client, Result};
 /// statistics, notification count, and timestamps for creation and
 /// updates.
 #[derive(Debug, Default, Clone, PartialEq, Deserialize, Serialize)]
-#[serde(rename_all(deserialize = "camelCase"))]
+#[serde(default, rename_all(deserialize = "camelCase"))]
 pub struct User {
     /// The ID of the user.
     pub id: i32,


### PR DESCRIPTION
* Enable wasm32 support

- Moved `openssl` dependency to `not(target_arch = "wasm32")` to allow compilation on WASM targets where OpenSSL is not supported or needed (reqwest uses fetch API).
- Enabled `chrono`'s `wasmbind` feature for `target_arch = "wasm32"` to support `Local::now()` using JS Date API.